### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ set(EXTENSION_HOMEPAGE "https://github.com/SlicerMicro/Slicer-TITAN")
 set(EXTENSION_CATEGORY "Analysis")
 set(EXTENSION_CONTRIBUTORS "Sindhura Thirumal (Queen's University)")
 set(EXTENSION_DESCRIPTION "TITAN is responsible for the pre-processing and analysis tasks of imaging mass cytometry (IMC) data. It performs visualization, segmentation, and various analyses functions on IMC data.")
-set(EXTENSION_ICONURL "https://user-images.githubusercontent.com/21988487/126827263-15f356e4-bef0-4244-8e0e-8a763e223242.PNG")
-set(EXTENSION_SCREENSHOTURLS "https://user-images.githubusercontent.com/21988487/126827330-1b7fec78-3358-4d61-b2a9-9510cc3d13c8.png")
+set(EXTENSION_ICONURL "https://raw.githubusercontent.com/sindhurathiru/SlicerTITAN/master/HypModuleCode/Resources/Icons/logo%20v2.PNG")
+set(EXTENSION_SCREENSHOTURLS "https://user-images.githubusercontent.com/21988487/125518905-0ca9aeb4-a904-415d-80f1-e5afa04cd938.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 
 #-----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13.4)
 
-project(HypModule2)
+project(TITAN)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.